### PR TITLE
Blood: Add diving suit to powerup HUD feature

### DIFF
--- a/source/blood/src/view.cpp
+++ b/source/blood/src/view.cpp
@@ -1373,7 +1373,7 @@ void viewBurnTime(int gScale)
     }
 }
 
-#define kPowerUps 11
+#define kPowerUps 12
 
 const struct POWERUPDISPLAY {
     int nTile;
@@ -1393,6 +1393,8 @@ const struct POWERUPDISPLAY {
     {gPowerUpInfo[kPwUpAsbestArmor].picnum, fix16_from_float(0.3f), 9}, // asbestos armor
     {gPowerUpInfo[kPwUpGrowShroom].picnum, fix16_from_float(0.4f), 4}, // grow shroom
     {gPowerUpInfo[kPwUpShrinkShroom].picnum, fix16_from_float(0.4f), 4}, // shrink shroom
+
+    {gPowerUpInfo[kPwUpDivingSuit].picnum, fix16_from_float(0.3f), 9}, // diving suit supply
 };
 
 void viewDrawPowerUps(PLAYER* pPlayer)
@@ -1414,6 +1416,8 @@ void viewDrawPowerUps(PLAYER* pPlayer)
     nPowerActive[8] = pPlayer->pwUpTime[kPwUpAsbestArmor]; // asbestos armor
     nPowerActive[9] = pPlayer->pwUpTime[kPwUpGrowShroom]; // grow shroom
     nPowerActive[10] = pPlayer->pwUpTime[kPwUpShrinkShroom]; // shrink shroom
+
+    nPowerActive[11] = pPlayer->isUnderwater && packItemActive(pPlayer, kPackDivingSuit) ? pPlayer->pwUpTime[kPwUpDivingSuit] : 0; // diving suit supply
 
     int nSortPower[kPowerUps+1];
     unsigned char nSortIndex[kPowerUps+1];


### PR DESCRIPTION
This PR addresses #907 by adding the current remaining air supply of the diving suit while underwater to the powerup HUD display.

![blud0001](https://github.com/user-attachments/assets/3a9221c2-902c-45dd-ab54-cc21732cad17)

Fixes #907