### PR TITLE
Blood: Properly flush input for cutscenes

### DIFF
--- a/source/blood/src/controls.cpp
+++ b/source/blood/src/controls.cpp
@@ -49,6 +49,7 @@ int32_t ctrlCheckAllInput(void)
 void ctrlClearAllInput(void)
 {
     KB_FlushKeyboardQueue();
+    KB_FlushKeyboardQueueScans();
     KB_ClearKeysDown();
     MOUSE_ClearAllButtons();
     JOYSTICK_ClearAllButtons();

--- a/source/blood/src/credits.cpp
+++ b/source/blood/src/credits.cpp
@@ -52,6 +52,7 @@ inline char keyJoyGetScan(void)
 char Wait(int nTicks)
 {
     totalclock = 0;
+    ctrlClearAllInput();
     while (totalclock < nTicks)
     {
         gameHandleEvents();


### PR DESCRIPTION
This PR fixes the weird intro skip for the start of the game, and adds an additional `KB_FlushKeyboardQueueScans()` clear to `ctrlClearAllInput()` much like how `CGameMenuItemKeyList::Scan()` does.