### PR TITLE
Revert "engine: lower Polymost SCISDIST to 0.1f"

### DIFF
--- a/source/build/src/polymost.cpp
+++ b/source/build/src/polymost.cpp
@@ -82,7 +82,7 @@ static float dxb1[MAXWALLSB], dxb2[MAXWALLSB];
 
 //POGOTODO: the SCISDIST could be set to 0 now to allow close objects to render properly,
 //          but there's a nasty rendering bug that needs to be dug into when setting SCISDIST lower than 1
-#define SCISDIST 0.1f  //close plane clipping distance
+#define SCISDIST 1.f  //close plane clipping distance
 
 #define SOFTROTMAT 0
 


### PR DESCRIPTION
This reverts commit c07a22ed4f68bbc9633affa1c90b24bf4e5f4124.

Fixes #812