### PR TITLE
Blood: Move input polling at start of game loop

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1898,6 +1898,7 @@ RESTART:
             }
             if (numplayers == 1)
                 gBufferJitter = 0;
+            ctrlGetInput();
             if (totalclock >= gNetFifoClock && ready2send)
             {
                 do
@@ -1905,7 +1906,6 @@ RESTART:
                     if (!frameJustDrawn)
                         break;
                     frameJustDrawn = false;
-                    ctrlGetInput();
                     gNetInput = gInput;
                     gInput = {};
                     do


### PR DESCRIPTION
This PR improves mouse aiming and input polling responsiveness by placing it at the top of the main loop, which will poll inputs regardless if a frame is ready to be drawn or not - instead of only polling input when a frame is being drawn.