### PR TITLE
Blood: Don't poll input twice for same frame while game is active

### DIFF
--- a/source/blood/src/blood.cpp
+++ b/source/blood/src/blood.cpp
@@ -1984,7 +1984,8 @@ RESTART:
 
             OSD_DispatchQueued();
 
-            ctrlGetInput();
+            if (!gGameStarted)
+                ctrlGetInput();
 
             switch (gInputMode)
             {


### PR DESCRIPTION
This PR reduces uselessly polling input twice while the game is active.

For example, if the player bound key `\` to noclip, it would toggle it twice in the same frame because of the double input polling.

By forcing it to only read once while the game is active, it'll fix this issue.