### PR TITLE
Blood: Scale 2D map view to output resolution

### DIFF
--- a/source/blood/src/map2d.cpp
+++ b/source/blood/src/map2d.cpp
@@ -216,7 +216,7 @@ void CViewMap::Draw(void)
 
 void CViewMap::Process(int nX, int nY, short nAng)
 {
-    nZoom = gZoom*((ydim/200)>>1); // scale to display resolution
+    nZoom = scale(gZoom, ydim, 200) >> 1; // scale to display resolution
     if (bFollowMode)
     {
         x = nX;

--- a/source/blood/src/map2d.cpp
+++ b/source/blood/src/map2d.cpp
@@ -216,7 +216,7 @@ void CViewMap::Draw(void)
 
 void CViewMap::Process(int nX, int nY, short nAng)
 {
-    nZoom = gZoom;
+    nZoom = gZoom*((ydim/200)>>1); // scale to display resolution
     if (bFollowMode)
     {
         x = nX;


### PR DESCRIPTION
This PR fixes a bug where the 2D map view does not scale to the output window size.

Below is an example of the issue in action. This is set to maximum map zoom.

### Before

<img width="2560" height="1600" alt="before" src="https://github.com/user-attachments/assets/a8e63ba2-2557-48c6-8e0d-2fa3588509d3" />

### After

<img width="2560" height="1600" alt="after" src="https://github.com/user-attachments/assets/4dcca421-aa6d-47a2-a244-d6aa0c441b50" />

### DOSBOX reference (640x400)

<img width="640" height="480" alt="dosbox" src="https://github.com/user-attachments/assets/41805964-52ac-4552-b2fe-91cc15c52d17" />